### PR TITLE
Recent posts should be a class not ID

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -67,7 +67,7 @@
         </section>
 
     <!-- Posts List -->
-        <section id="recent-posts">
+        <section class="recent-posts">
             <div class="mini-posts">
                 <header>
                     <h3>Recent Posts</h3>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -32,7 +32,7 @@
   </section>
 
   <!-- Posts List -->
-  <section id="recent-posts">
+  <section class="recent-posts">
     <div class="mini-posts">
       <header>
         <h3>Recent Posts</h3>


### PR DESCRIPTION
Fix issue where htmlproofer fails due to the two occurrences of the **recent-posts** section being given an ID rather than a class.