### PR TITLE
Email share link - fix htmlproofer

### DIFF
--- a/layouts/partials/share-links.html
+++ b/layouts/partials/share-links.html
@@ -58,7 +58,7 @@
 
 <!-- Email -->
 <li>
-  <a href="mailto:?subject=Check out this post by {{ .Params.author }}&body={{ .Permalink }}" target="_blank" class="share-btn email">
+  <a href="mailto:@?subject=Check out this post by {{ .Params.author }}&body={{ .Permalink }}" target="_blank" class="share-btn email">
     <i class="fa fa-envelope"></i>
     <p>Email</p>
   </a>


### PR DESCRIPTION
HTML Proofer seems to moan when the email address is empty in a `mailto` link. This fixes that.