### PR TITLE
Use .Site.RSSLink instead of .RSSLink

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -23,7 +23,7 @@
       <ul class="icons">
         {{ if .Site.Params.rssAppearAtTop }}
           <li>
-            <a href="{{ .RSSLink }}" type="application/rss+xml" target="_blank" title="RSS" class="fa fa-rss"></a>
+            <a href="{{ .Site.RSSLink }}" type="application/rss+xml" target="_blank" title="RSS" class="fa fa-rss"></a>
           </li>
         {{ end }}
         {{ partial "social" . }}


### PR DESCRIPTION
Use `.Site.RSSLink` instead of `.RSSLink`. Ensures RSS works throughout the entire site and not just the homepage.