### PR TITLE
Use contact us page instead of email address in plain text on 404 err…

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -244,7 +244,7 @@
 	</div>
 	<div class="buttons-container">
 		<a class="border-button" href="{{ "/" | relURL }}">Go To Homepage</a>
-		<a class="border-button" href="mailto:{{ .Site.Social.email }}">Report A Problem</a>
+		<a class="border-button" href="{{ "/contact/" | relURL }}">Report A Problem</a>
 	</div>
 </div>
 


### PR DESCRIPTION
I don't want my email address displayed in plain text on any part of the website. The 404 page fails HTML proofer with no email address specified. This PR changes the "report a problem" link to the **Contact Us** page.